### PR TITLE
Fix visibility of actions (maybe)

### DIFF
--- a/builder/action.yml
+++ b/builder/action.yml
@@ -14,7 +14,12 @@ runs:
   using: 'composite'
 
   steps:
+    # Weird workaround so that the other actions and workflows calling this can see it
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.workflow_ref }}
+        path: .
+        repository: eshwen/adrenaline
 
     - name: Set up Python ${{ inputs.python-version }}
       uses: actions/setup-python@v4

--- a/workflows/python-test.yml
+++ b/workflows/python-test.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Test t-wave
+      - name: Test Python code
         if: always()
         uses: ./test-python
         with:


### PR DESCRIPTION
When the workflows in this repo are called from another repo, they can't seem to find the `builder`, `check-python`, `test-python` actions

So I might have to recursively check out this repo so the actions are visible when called