### PR TITLE
Remove concurrency in workflows

### DIFF
--- a/.github/workflows/api-docs-build.yml
+++ b/.github/workflows/api-docs-build.yml
@@ -13,12 +13,7 @@ on:
         type: string
         default: ''
 
-concurrency:
-  group: docs-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
-
 jobs:
-
   docs:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/api-docs-build.yml
+++ b/.github/workflows/api-docs-build.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: eshwen/adrenaline/builder@v0.2.4
+      - uses: eshwen/adrenaline/builder@v0.2.5
         with:
           python-version: ${{ inputs.python-version }}
           install-dev-deps: true

--- a/.github/workflows/python-quality-check.yml
+++ b/.github/workflows/python-quality-check.yml
@@ -13,10 +13,6 @@ on:
         type: string
         default: '.'
 
-concurrency:
-  group: check-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-quality-check.yml
+++ b/.github/workflows/python-quality-check.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Check code quality
         if: always()
-        uses: eshwen/adrenaline/check-python@v0.2.4
+        uses: eshwen/adrenaline/check-python@v0.2.5
         with:
           python-version: ${{ inputs.python-version }}
           path: ${{ inputs.path }}

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Test Python code
         if: always()
-        uses: eshwen/adrenaline/test-python@v0.2.4
+        uses: eshwen/adrenaline/test-python@v0.2.5
         with:
           pkg-name: ${{ inputs.pkg-name }}
           tests-path: ${{ inputs.tests-path }}

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -17,10 +17,6 @@ on:
         type: string
         default: 'tests'
 
-concurrency:
-  group: test-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/check-python/action.yml
+++ b/check-python/action.yml
@@ -19,7 +19,7 @@ runs:
     - uses: actions/checkout@v4
 
     - name: Build Python
-      uses: eshwen/adrenaline/builder@v0.2.4
+      uses: eshwen/adrenaline/builder@v0.2.5
       with:
         python-version: ${{ inputs.python-version }}
         install-dev-deps: true

--- a/test-python/action.yml
+++ b/test-python/action.yml
@@ -20,7 +20,7 @@ runs:
     - uses: actions/checkout@v4
 
     - name: Build Python
-      uses: eshwen/adrenaline/builder@v0.2.4
+      uses: eshwen/adrenaline/builder@v0.2.5
       with:
         python-version: ${{ inputs.python-version }}
         install-dev-deps: true


### PR DESCRIPTION
Specifying the concurrency in this repo, when caller workflows are in other repos, could get messy. So just remove