### PR TITLE
Use new ruff syntax

### DIFF
--- a/check-python/action.yml
+++ b/check-python/action.yml
@@ -28,7 +28,7 @@ runs:
       name: Ruff lint
       if: always()
       shell: bash
-      run: poetry run ruff ${{ inputs.path }}
+      run: poetry run ruff check ${{ inputs.path }}
 
     - id: ruff_format
       name: Ruff format


### PR DESCRIPTION
At some stage, ruff _enforced_ the new `ruff check` command over just `ruff`. So, use that going forward