### PR TITLE
Preserve caller workspace in uv composite action checkout

### DIFF
--- a/.github/workflows/api-docs-build-poetry.yml
+++ b/.github/workflows/api-docs-build-poetry.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: eshwen/adrenaline/poetry/builder@v0.8.1
+      - uses: eshwen/adrenaline/poetry/builder@v0.8.2
         with:
           python-version: ${{ inputs.python-version }}
           install-dev-deps: true

--- a/.github/workflows/api-docs-build-uv.yml
+++ b/.github/workflows/api-docs-build-uv.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: eshwen/adrenaline/uv/builder@v0.8.1
+      - uses: eshwen/adrenaline/uv/builder@v0.8.2
         with:
           python-version-file: ${{ inputs.python-version-file }}
           install-dev-deps: true

--- a/.github/workflows/python-quality-check-poetry.yml
+++ b/.github/workflows/python-quality-check-poetry.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Check code quality
         if: always()
-        uses: eshwen/adrenaline/poetry/check-python@v0.8.1
+        uses: eshwen/adrenaline/poetry/check-python@v0.8.2
         with:
           python-version: ${{ inputs.python-version }}
           path: ${{ inputs.path }}

--- a/.github/workflows/python-quality-check-uv.yml
+++ b/.github/workflows/python-quality-check-uv.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Check code quality
         if: always()
-        uses: eshwen/adrenaline/uv/check-python@v0.8.1
+        uses: eshwen/adrenaline/uv/check-python@v0.8.2
         with:
           python-version-file: ${{ inputs.python-version-file }}
           uv-version: ${{ inputs.uv-version }}

--- a/.github/workflows/python-test-poetry.yml
+++ b/.github/workflows/python-test-poetry.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Test Python code
         if: always()
-        uses: eshwen/adrenaline/poetry/test-python@v0.8.1
+        uses: eshwen/adrenaline/poetry/test-python@v0.8.2
         with:
           pkg-name: ${{ inputs.pkg-name }}
           tests-path: ${{ inputs.tests-path }}

--- a/.github/workflows/python-test-uv.yml
+++ b/.github/workflows/python-test-uv.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Test Python code
         if: always()
-        uses: eshwen/adrenaline/uv/test-python@v0.8.1
+        uses: eshwen/adrenaline/uv/test-python@v0.8.2
         with:
           python-version-file: ${{ inputs.python-version-file }}
           uv-version: ${{ inputs.uv-version }}

--- a/poetry/check-python/action.yml
+++ b/poetry/check-python/action.yml
@@ -19,7 +19,7 @@ runs:
     - uses: actions/checkout@v4
 
     - name: Build Python
-      uses: eshwen/adrenaline/poetry/builder@v0.8.1
+      uses: eshwen/adrenaline/poetry/builder@v0.8.2
       with:
         python-version: ${{ inputs.python-version }}
         install-dev-deps: true

--- a/poetry/test-python/action.yml
+++ b/poetry/test-python/action.yml
@@ -24,7 +24,7 @@ runs:
     - uses: actions/checkout@v4
 
     - name: Build Python
-      uses: eshwen/adrenaline/poetry/builder@v0.8.1
+      uses: eshwen/adrenaline/poetry/builder@v0.8.2
       with:
         python-version: ${{ inputs.python-version }}
         install-dev-deps: true

--- a/uv/builder/action.yml
+++ b/uv/builder/action.yml
@@ -19,6 +19,8 @@ runs:
 
   steps:
     - uses: actions/checkout@v6
+      with:
+        clean: false
     - name: Set up Python
       uses: actions/setup-python@v6
       with:

--- a/uv/check-python/action.yml
+++ b/uv/check-python/action.yml
@@ -22,7 +22,7 @@ runs:
     - uses: actions/checkout@v6
 
     - name: Build Project
-      uses: eshwen/adrenaline/uv/builder@v0.8.1
+      uses: eshwen/adrenaline/uv/builder@v0.8.2
       with:
         python-version-file: ${{ inputs.python-version-file }}
         install-dev-deps: true

--- a/uv/test-python/action.yml
+++ b/uv/test-python/action.yml
@@ -24,7 +24,9 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
+      with:
+        clean: false
 
     - name: Build Project
       uses: eshwen/adrenaline/uv/builder@v0.8.0

--- a/uv/test-python/action.yml
+++ b/uv/test-python/action.yml
@@ -29,7 +29,7 @@ runs:
         clean: false
 
     - name: Build Project
-      uses: eshwen/adrenaline/uv/builder@v0.8.1
+      uses: eshwen/adrenaline/uv/builder@v0.8.2
       with:
         python-version-file: ${{ inputs.python-version-file }}
         install-dev-deps: true


### PR DESCRIPTION
Setting `clean: false` on both inner checkouts (uv/builder and uv/test-python) preserves the caller's workspace. The motivating use case is matrix Python testing: a caller can `echo "${{ matrix.python-version }}"  > .python-version` between the outer checkout and the action call, and the inner setup-python will respect that pin instead of falling back to pyproject.toml's requires-python constraint.